### PR TITLE
Feature: $comment for fail2ban::filter

### DIFF
--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -18,13 +18,15 @@
 # @param includes_before An array of files to include prior to the main definition of this filter.
 # @param includes_after An array of files to include after the main definition of this filter.
 # @param additional_defs An array of additional definition lines to include in this filter's config file. 
+# @param comment An optional comment that will be inserted in the filter's config file.
 define fail2ban::filter (
   Array[String] $failregexes,
   Enum['present', 'absent'] $ensure = 'present',
   Array[String] $ignoreregexes = [],
   Array[String] $includes_before = [],
   Array[String] $includes_after = [],
-  Array[String] $additional_defs = []
+  Array[String] $additional_defs = [],
+  String $comment = "",
   ) {
 
   include ::fail2ban::config

--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -26,7 +26,7 @@ define fail2ban::filter (
   Array[String] $includes_before = [],
   Array[String] $includes_after = [],
   Array[String] $additional_defs = [],
-  String $comment = "",
+  String $comment = '',
   ) {
 
   include ::fail2ban::config

--- a/spec/defines/filter_spec.rb
+++ b/spec/defines/filter_spec.rb
@@ -32,7 +32,8 @@ describe 'fail2ban::filter' do
             without_content(/after *=/).
             with_content(/\[Definition\]/).
             with_content(/failregex *= *aaa\s+bbb\s+ccc/).
-            with_content(/ignoreregex *= *$/)
+            with_content(/ignoreregex *= *$/).
+            with_content(/# Managed by Puppet\n\n/)
         end
       end
       context 'with all params' do
@@ -44,6 +45,7 @@ describe 'fail2ban::filter' do
             :includes_before => ['ib1', 'ib2'],
             :includes_after  => ['ia1', 'ia2'],
             :additional_defs  => ['abc', 'def = ghi'],
+            :comment  => 'Filter that applies on wigwam',
           }
         end
         let (:title) {'wigwam'}
@@ -67,7 +69,8 @@ describe 'fail2ban::filter' do
             with_content(/^abc$/).
             with_content(/^def = ghi/).
             with_content(/failregex *= *xxx$/).
-            with_content(/ignoreregex *= *iii\s*jjj$/)
+            with_content(/ignoreregex *= *iii\s*jjj$/).
+            with_content(/# Managed by Puppet\n# Filter that applies on wigwam\n/)
         end
       end
     end

--- a/templates/filter.erb
+++ b/templates/filter.erb
@@ -1,5 +1,8 @@
 # Fail2ban filter file <%= @name %>.conf
 # Managed by Puppet
+<% if ! @comment.empty? -%>
+# <%= @comment %>
+<% end -%>
 
 <% if ! @includes_before.empty? or ! @includes_after.empty? -%>
 [INCLUDES]


### PR DESCRIPTION
I often need a comment in config files that I deploy.
It allows to keep track of why things have been done in _that_ specific way.

If you agree with this feature, I can do the same for `fail2ban::jail` defined type.

Regards,