### PR TITLE
Feature: Add $comment parameter to `jail` defined type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /pkg/*
-/spec/fixtures/modules/*
+/spec/fixtures/*
 /Gemfile.lock
 *~
 \#*\#
 /coverage/*
+.bundle

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,8 +69,8 @@ class fail2ban (
   contain ::fail2ban::config
   contain ::fail2ban::service
 
-  Class['::fail2ban::install'] ->
-  Class['::fail2ban::config'] ~>
-  Class['::fail2ban::service']
+  Class['::fail2ban::install']
+  -> Class['::fail2ban::config']
+  ~> Class['::fail2ban::service']
 
 }

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -43,6 +43,7 @@
 # @param ignoreip Hosts to ignore when applying this jail
 # @param order  Jails are applied in ascending order according to this parameter; Only for Debian < 7.
 # @param backend The backend to use for this jail.
+# @param comment An optional comment that will be inserted in the jail's config file.
 define fail2ban::jail (
   Optional[Variant[String, Integer[1,6535]]] $port = undef,
   Optional[String]  $filter = undef,
@@ -58,6 +59,7 @@ define fail2ban::jail (
   Array[Variant[IP::Address::NoSubnet, IP::Address::V4::CIDR, String]] $ignoreip = [],
   Optional[Integer] $order     = undef,
   Optional[Enum['pyinotify', 'gamin', 'polling', 'systemd', 'auto']] $backend  = undef,
+  Optional[String] $comment = '',
   ) {
 
   include ::fail2ban::config

--- a/spec/defines/jail_spec.rb
+++ b/spec/defines/jail_spec.rb
@@ -25,6 +25,7 @@ describe 'fail2ban::jail' do
               with_order(10). # 10 is the default provided by concat module.
               with_content(/^\[fooey\]/).
               with_content(/^enabled *= *true/).
+              with_content(/# Fail2ban jail fooey created by puppet\n\n/).
               without_content(/port/).
               without_content(/filter/).
               without_content(/logpath/).
@@ -46,6 +47,7 @@ describe 'fail2ban::jail' do
               with_mode('0644').
               with_content(/^\[fooey\]/).
               with_content(/^enabled *= *true/).
+              with_content(/# Fail2ban jail fooey created by puppet\n\n/).
               without_content(/port/).
               without_content(/filter/).
               without_content(/logpath/).
@@ -76,7 +78,8 @@ describe 'fail2ban::jail' do
             :bantime   => 187,
             :ignoreip  => ['foo.com', '172.24.8.0/24', '132.98.47.1'],
             :order     => 25,
-            :backend   => 'polling'
+            :backend   => 'polling',
+            :comment   => 'Jail protecting against yeah ddos',
           }
         end
         let (:title) {'wigwam'}
@@ -90,6 +93,7 @@ describe 'fail2ban::jail' do
             is_expected.to contain_concat__fragment('jail_wigwam').
               with_target('/etc/fail2ban/jail.local').
               with_order(25).
+              with_content(/# Fail2ban jail wigwam created by puppet\n# Jail protecting against yeah ddos\n/).
               with_content(/^\[wigwam\]/).
               with_content(/^enabled *= *false/).
               with_content(/port *= *4731/).
@@ -112,6 +116,7 @@ describe 'fail2ban::jail' do
               with_owner('root').
               with_group(expected_root_group).
               with_mode('0644').
+              with_content(/# Fail2ban jail wigwam created by puppet\n# Jail protecting against yeah ddos\n/).
               with_content(/^\[wigwam\]/).
               with_content(/^enabled *= *false/).
               with_content(/port *= *4731/).

--- a/templates/jail.erb
+++ b/templates/jail.erb
@@ -1,4 +1,7 @@
 # Fail2ban jail <%= @name %> created by puppet
+<% if ! @comment.empty? -%>
+# <%= @comment %>
+<% end -%>
 
 [<%= @name %>]
 enabled = <%= @enabled %>


### PR DESCRIPTION
As for the PR #1, here is a patch to add $comment parameter to `fail2ban::jail` type.

Regards,