### PR TITLE
Adding additional notifies

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -37,6 +37,7 @@ class fail2ban::config {
     group   => $root_group,
     mode    => '0400',
     content => template("${module_name}/fail2ban.local.erb"),
+    notify  => Class['::fail2ban::service'],
   }
 
   # Wheezy doesn't seem to support the jail.d pattern, so we
@@ -49,9 +50,10 @@ class fail2ban::config {
       }
     }
     concat { '/etc/fail2ban/jail.local':
-      owner => 'root',
-      group => $root_group,
-      mode  => '0644',
+      owner  => 'root',
+      group  => $root_group,
+      mode   => '0644',
+      notify => Class['::fail2ban::service'],
     }
     concat::fragment { 'jail_header':
       target  => '/etc/fail2ban/jail.local',
@@ -68,6 +70,7 @@ class fail2ban::config {
       owner   => 'root',
       group   => $root_group,
       mode    => '0700',
+      notify  => Class['::fail2ban::service'],
     }
     file { '/etc/fail2ban/jail.local':
       ensure  => file,
@@ -75,6 +78,7 @@ class fail2ban::config {
       group   => $root_group,
       mode    => '0400',
       content => template("${module_name}/jail.local.erb"),
+      notify  => Class['::fail2ban::service'],
     }
   }
 

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -94,6 +94,7 @@ define fail2ban::jail (
       owner   => 'root',
       group   => $::fail2ban::config::root_group,
       mode    => '0644',
+      notify  => Class['::fail2ban::service'],
     }
   }
   }


### PR DESCRIPTION
So that the service gets restarted whenever any of it's config changes, rather than just when the filters change.

This makes changes to the jails etc take effect immediately, ie it allows:
```
  include ::fail2ban
  ::fail2ban::jail{'sshd':}
```
To give you a working sshd jail immediately, without having to manually restart the service after applying it.