### PR TITLE
Removed deprecated data_provider

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,6 @@
   "source": "https://github.com/calmenergy/calmenergy-fail2ban",
   "project_page": "https://github.com/calmenergy/calmenergy-fail2ban",
   "issues_url": "https://github.com/calmenergy/calmenergy-fail2ban/issues",
-  "data_provider": "hiera",
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
```
2018-07-28 15:04:47,462 WARN  [qtp1930050803-62] [puppetserver] Puppet Defining "data_provider": "hiera" in metadata.json is deprecated. A 'hiera.yaml' file should be used instead
   (file: /etc/puppetlabs/code/environments/production/modules/fail2ban/metadata.json)
```